### PR TITLE
Add webrick as dependency for MacOs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 ruby '>=2.5.5'
 
 gem 'github-pages', group: :jekyll_plugins
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
See https://github.com/jekyll/jekyll/issues/8523

I'll try to bring this to the templates/carpentries/... as well, but for now I'm impatient :) 