### PR TITLE
docs: update CITATION

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "Please cite the following works when using this software."
 type: software
 title: "Scikit-HEP Tutorial"
-abstract: "FIXME"
+abstract: "Tutorial for Scikit-HEP: A collection of packages for particle physics analyses in Python."
 authors:
 - family-names: "Pivarski"
   given-names: "Jim"

--- a/CITATION
+++ b/CITATION
@@ -1,1 +1,17 @@
-Pivarski, Jim. Scikit-HEP Tutorial (2021). https://github.com/hsf-training/hsf-training-scikit-hep-webpage
+cff-version: 1.2.0
+message: "Please cite the following works when using this software."
+type: software
+title: "Scikit-HEP Tutorial"
+abstract: "FIXME"
+authors:
+- family-names: "Pivarski"
+  given-names: "Jim"
+  orcid: "https://orcid.org/0000-0002-6649-343X"
+  affiliation: "Princeton University"
+repository-code: "https://github.com/hsf-training/hsf-training-scikit-hep-webpage"
+url: "https://hsf-training.github.io/hsf-training-scikit-hep-webpage/"
+keywords:
+  - scikit-hep
+  - python
+  - training
+license: "CC-BY-4.0"


### PR DESCRIPTION
Updated `CITATION` according to `CITATION.cff` format, similar to hsf-training/hsf-training-matplotlib#75. A small abstract (one-liner maybe?) needs to be added.