### PR TITLE
chore: use normal code fences

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -20,36 +20,32 @@ keypoints:
 
 Most students start this module after a Python introduction or are already familiar with the *basics* of Python. For instance, you should be comfortable with the Python essentials such as assigning variables,
 
-~~~
+```python
 x = 5
-~~~
-{: .language-python}
+```
 
 if-statements,
 
-~~~
+```python
 if x < 5:
     print("small")
 else:
     print("big")
-~~~
-{: .language-python}
+```
 
 and loops.
 
-~~~
+```python
 for i in range(x):
      print(i)
-~~~
-{: .language-python}
+```
 
 Your data analysis will likely be full of statements like these, though the kinds of operations we'll be focusing on in this module have a form more like
 
-~~~
+```python
 import compiled_library
 compiled_library.do_computationally_expensive_thing(big_array)
-~~~
-{: .language-python}
+```
 
 The trick is for the Python-side code to be expressive enough and the compiled code to be general enough that you don't need a new `compiled_library` for each thing you want to do. The libraries presented in this module are designed with interfaces that let you express what you want to do in Python and have it run in compiled code.
 
@@ -57,36 +53,30 @@ The trick is for the Python-side code to be expressive enough and the compiled c
 
 The two most important data types for these interfaces are dicts
 
-~~~
+```python
 some_dict = {"word": 1, "another word": 2, "some other word": 3}
-~~~
-{: .language-python}
-~~~
+```
+```python
 some_dict["some other word"]
-~~~
-{: .language-python}
-~~~
+```
+```python
 for key in some_dict:
     print(key, some_dict[key])
-~~~
-{: .language-python}
+```
 
 and arrays
 
-~~~
+```python
 import numpy as np
 some_array = np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
-~~~
-{: .language-python}
-~~~
+```
+```python
 some_array[4]
-~~~
-{: .language-python}
-~~~
+```
+```python
 for x in some_array:
     print(x)
-~~~
-{: .language-python}
+```
 
 Although these data types are important, what's more important is the *interfaces* to these types. They both represent functions from keys to values:
 
@@ -99,98 +89,87 @@ Most of the types we will see in this module also map strings or integers to dat
 
 For dicts, the things that can go in square brackets (its "domain," as a function) are its `keys`.
 
-~~~
+```python
 some_dict = {"word": 1, "another word": 2, "some other word": 3}
 some_dict.keys()
-~~~
-{: .language-python}
+```
 
 Nothing other than these keys can be used in square brackets
 
-~~~
+```python
 some_dict["something I made up"]
-~~~
-{: .language-python}
+```
 
 unless it has been added to the dict.
 
-~~~
+```python
 some_dict["something I made up"] = 123
 some_dict["something I made up"]
-~~~
-{: .language-python}
+```
 
 The things that can come out of a dict (its "range," as a function) are its `values`.
 
-~~~
+```python
 some_dict.values()
-~~~
-{: .language-python}
+```
 
 You can get keys and values as 2-tuples by asking for its `items`.
 
-~~~
+```python
 some_dict.items()
 
 for key, value in some_dict.items():
     print(key, value)
-~~~
-{: .language-python}
+```
 
 ## Review of the array interface
 
 For arrays, the things that can go in square brackets (its "domain," as a function) are integers from zero up to but not including its length.
 
-~~~
+```python
 import numpy as np
 some_array = np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
 some_array[0]   # okay
 some_array[1]   # okay
 some_array[9]   # okay
 some_array[10]  # not okay
-~~~
-{: .language-python}
+```
 
 You can get the length of an array (and the number of keys in a dict) with `len`:
 
-~~~
+```python
 len(some_array)
-~~~
-{: .language-python}
+```
 
 It's important to remember that index `0` corresponds to the first item in the array, `1` to the second, and so on, which is why `len(some_array)` is not a valid index.
 
 Negative indexes are allowed, but they count from the end of the list to the beginning. For instance,
 
-~~~
+```python
 some_array[-1]
-~~~
-{: .language-python}
+```
 
 returns the last item. **Quick quiz:** which negative value returns the first item, equivalent to `0`?
 
 Arrays can also be "sliced" by putting a colon (`:`) between the starting and stopping index.
 
-~~~
+```python
 some_array[2:7]
-~~~
-{: .language-python}
+```
 
 **Quick quiz:** why is `7.7` not included in the output?
 
 The above is common to all Python sequences. Arrays, however, can be multidimensional and this allows for more kinds of slicing.
 
-~~~
+```python
 array3d = np.arange(2*3*5).reshape(2, 3, 5)
-~~~
-{: .language-python}
+```
 
 Separating two slices in the square brackets with a comma
 
-~~~
+```python
 array3d[:, 1:, 1:]
-~~~
-{: .language-python}
+```
 
 selects the following:
 
@@ -206,48 +185,43 @@ In addition to integers and slices, arrays can be included in the square bracket
 
 An array of booleans with the same length as the sliced array selects all items that line up with `True`.
 
-~~~
+```python
 some_array    = np.array([ 0.0,  1.1,  2.2,  3.3,  4.4,   5.5,  6.6,   7.7,  8.8,   9.9])
 boolean_array = np.array([True, True, True, True, True, False, True, False, True, False])
 
 some_array[boolean_array]
-~~~
-{: .language-python}
+```
 
 An array of integers selects items by index.
 
-~~~
+```python
 some_array    = np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
 integer_array = np.array([  0,   1,   2,   3,   4,        6,        8     ])
 
 some_array[integer_array]
-~~~
-{: .language-python}
+```
 
 Integer-slicing is more general than boolean-slicing because an array of integers can also change the order of the data and repeat items.
 
-~~~
+```python
 some_array[np.array([4, 2, 2, 2, 9, 8, 3])]
-~~~
-{: .language-python}
+```
 
 Both come up in natural contexts. Boolean arrays often come from performing a calculation on all elements of an array that returns boolean values.
 
-~~~
+```python
 even_valued_items = (some_array * 10 % 2 == 0)
 
 some_array[even_valued_items]
-~~~
-{: .language-python}
+```
 
 This is how we'll be computing and applying cuts: expressions like
 
-~~~
+```python
 good_muon_cut = (muons.pt > 10) & (abs(muons.eta) < 2.4)
 
 good_muons = muons[good_muon_cut]
-~~~
-{: .language-python}
+```
 
 ## Logical operators: `&`, `|`, `~`, and parentheses
 
@@ -257,14 +231,13 @@ If you're coming from non-array Python, you might expect them to be `and`, `or`,
 
 In array expressions (unfortunately!), we have to use Python's bitwise operators, `&`, `|`, `~`, and ensure that comparisons are surrounded in parentheses. Python's `and`, `or`, `not` are not applied across arrays and bitwise operators have a surprising operator-precedence.
 
-~~~
+```python
 x = 0
 
 x > -10 & x < 10  # probably not what you expect!
 
 (x > -10) & (x < 10)
-~~~
-{: .language-python}
+```
 
 ![bitwise-operator-parentheses]({{ page.root }}/fig/bitwise-operator-parentheses.png)
 
@@ -272,20 +245,18 @@ x > -10 & x < 10  # probably not what you expect!
 
 Expressions like
 
-~~~
+```python
 even_valued_items = (some_array * 10 % 2 == 0)
-~~~
-{: .language-python}
+```
 
 perform the `*`, `%`, and `==` operations on every item of `some_array` and return arrays. Without NumPy, the above would have to be written as
 
-~~~
+```python
 even_valued_items = []
 
 for x in some_array:
     even_valued_items.append(x * 10 % 2 == 0)
-~~~
-{: .language-python}
+```
 
 This is more cumbersome when you want to apply a mathematical formula to every item of a collection, but it is also considerably slower. Every step in a Python `for` loop performs sanity checks that are unnecessary for numerical values with uniform type, checks that would happen at compile-time in a compiled library. NumPy *is* a compiled library; its `*`, `%`, and `==` operators, as well as many other functions, are performed in fast, compiled loops.
 

--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -37,13 +37,14 @@ and loops.
 
 ```python
 for i in range(x):
-     print(i)
+    print(i)
 ```
 
 Your data analysis will likely be full of statements like these, though the kinds of operations we'll be focusing on in this module have a form more like
 
 ```python
 import compiled_library
+
 compiled_library.do_computationally_expensive_thing(big_array)
 ```
 
@@ -68,6 +69,7 @@ and arrays
 
 ```python
 import numpy as np
+
 some_array = np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
 ```
 ```python
@@ -128,10 +130,11 @@ For arrays, the things that can go in square brackets (its "domain," as a functi
 
 ```python
 import numpy as np
+
 some_array = np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
-some_array[0]   # okay
-some_array[1]   # okay
-some_array[9]   # okay
+some_array[0]  # okay
+some_array[1]  # okay
+some_array[9]  # okay
 some_array[10]  # not okay
 ```
 
@@ -162,7 +165,7 @@ some_array[2:7]
 The above is common to all Python sequences. Arrays, however, can be multidimensional and this allows for more kinds of slicing.
 
 ```python
-array3d = np.arange(2*3*5).reshape(2, 3, 5)
+array3d = np.arange(2 * 3 * 5).reshape(2, 3, 5)
 ```
 
 Separating two slices in the square brackets with a comma
@@ -186,8 +189,10 @@ In addition to integers and slices, arrays can be included in the square bracket
 An array of booleans with the same length as the sliced array selects all items that line up with `True`.
 
 ```python
-some_array    = np.array([ 0.0,  1.1,  2.2,  3.3,  4.4,   5.5,  6.6,   7.7,  8.8,   9.9])
-boolean_array = np.array([True, True, True, True, True, False, True, False, True, False])
+some_array = np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
+boolean_array = np.array(
+    [True, True, True, True, True, False, True, False, True, False]
+)
 
 some_array[boolean_array]
 ```
@@ -195,8 +200,8 @@ some_array[boolean_array]
 An array of integers selects items by index.
 
 ```python
-some_array    = np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
-integer_array = np.array([  0,   1,   2,   3,   4,        6,        8     ])
+some_array = np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
+integer_array = np.array([0, 1, 2, 3, 4, 6, 8])
 
 some_array[integer_array]
 ```
@@ -210,7 +215,7 @@ some_array[np.array([4, 2, 2, 2, 9, 8, 3])]
 Both come up in natural contexts. Boolean arrays often come from performing a calculation on all elements of an array that returns boolean values.
 
 ```python
-even_valued_items = (some_array * 10 % 2 == 0)
+even_valued_items = some_array * 10 % 2 == 0
 
 some_array[even_valued_items]
 ```
@@ -246,7 +251,7 @@ x > -10 & x < 10  # probably not what you expect!
 Expressions like
 
 ```python
-even_valued_items = (some_array * 10 % 2 == 0)
+even_valued_items = some_array * 10 % 2 == 0
 ```
 
 perform the `*`, `%`, and `==` operations on every item of `some_array` and return arrays. Without NumPy, the above would have to be written as

--- a/_episodes/02-uproot.md
+++ b/_episodes/02-uproot.md
@@ -34,9 +34,13 @@ To open a file for reading, pass the name of the file to [uproot.open](https://u
 
 ```python
 import skhep_testdata
-filename = skhep_testdata.data_path("uproot-Event.root")   # downloads this test file and gets a local path to it
+
+filename = skhep_testdata.data_path(
+    "uproot-Event.root"
+)  # downloads this test file and gets a local path to it
 
 import uproot
+
 file = uproot.open(filename)
 ```
 
@@ -76,7 +80,7 @@ Uproot histograms also satisfy the [UHI plotting protocol](https://uhi.readthedo
 ```python
 h.values()
 h.variances()
-h.axis("x").edges()   # "x", "y", "z" or 0, 1, 2
+h.axis("x").edges()  # "x", "y", "z" or 0, 1, 2
 ```
 
 ## Reading a TTree
@@ -151,7 +155,10 @@ output1["some_string"] = "This will be a TObjString."
 output1["some_histogram"] = file["hstat"]
 
 import numpy as np
-output1["nested_directory/another_histogram"] = np.histogram(np.random.normal(0, 1, 1000000))
+
+output1["nested_directory/another_histogram"] = np.histogram(
+    np.random.normal(0, 1, 1000000)
+)
 ```
 
 In ROOT, the name of an object is a property of the object, but in Uproot, it's a key in the TDirectory that holds the object, so that's why the name is on the left-hand side of the assignment, in square brackets. Only the data types listed in the blue box [in the documentation](https://uproot.readthedocs.io/en/latest/basic.html#writing-objects-to-a-file) are supported: mostly just histograms.
@@ -165,18 +172,31 @@ One way to do this is to assign the first batch and `extend` it with subsequent 
 ```python
 import numpy as np
 
-output1["tree1"] = {"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)}
-output1["tree1"].extend({"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)})
-output1["tree1"].extend({"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)})
+output1["tree1"] = {
+    "x": np.random.randint(0, 10, 1000000),
+    "y": np.random.normal(0, 1, 1000000),
+}
+output1["tree1"].extend(
+    {"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)}
+)
+output1["tree1"].extend(
+    {"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)}
+)
 ```
 
 another is to create an empty TTree with [uproot.WritableDirectory.mktree](https://uproot.readthedocs.io/en/latest/uproot.writing.writable.WritableDirectory.html#mktree), so that every write is an extension.
 
 ```python
 output1.mktree("tree2", {"x": np.int32, "y": np.float64})
-output1["tree2"].extend({"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)})
-output1["tree2"].extend({"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)})
-output1["tree2"].extend({"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)})
+output1["tree2"].extend(
+    {"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)}
+)
+output1["tree2"].extend(
+    {"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)}
+)
+output1["tree2"].extend(
+    {"x": np.random.randint(0, 10, 1000000), "y": np.random.normal(0, 1, 1000000)}
+)
 ```
 
 Performance tips are given in the next lesson, but in general, it pays to write few large batches, rather than many small batches.

--- a/_episodes/03-ttree-details.md
+++ b/_episodes/03-ttree-details.md
@@ -36,7 +36,10 @@ As a data analyst, you'll likely be concerned with TTrees and TBranches first-ha
 
 ```python
 import uproot
-file = uproot.open("root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root")
+
+file = uproot.open(
+    "root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root"
+)
 file.classnames()
 ```
 
@@ -79,7 +82,9 @@ These are the building blocks of a parallel data reader: each is responsible for
 Suppose you know that you will need all of the muon TBranches. Asking for them in one request is more efficient than asking for each TBranch individually because the server can be working on reading the later TBaskets from disk while the earlier TBaskets are being sent over the network to you. Whereas a TBranch has an `array` method, the TTree has an `arrays` (plural) method for getting multiple arrays.
 
 ```python
-muons = tree.arrays(["Muon_pt", "Muon_eta", "Muon_phi", "Muon_mass", "Muon_charge"], entry_stop=1000)
+muons = tree.arrays(
+    ["Muon_pt", "Muon_eta", "Muon_phi", "Muon_mass", "Muon_charge"], entry_stop=1000
+)
 muons
 ```
 
@@ -88,7 +93,7 @@ Now all five of these TBranches are in the output, `muons`, which is an Awkward 
 ```python
 muons["Muon_pt"]
 muons["Muon_eta"]
-muons["Muon_phi"]   # etc.
+muons["Muon_phi"]  # etc.
 ```
 
 > ## Beware! It's `tree.arrays` that actually reads the data!
@@ -120,16 +125,21 @@ The best way to figure out what you're doing is to tinker with small datasets, a
 
 ```python
 muons = tree.arrays(entry_stop=1000)
-cut = (muons["nMuon"] == 2)
+cut = muons["nMuon"] == 2
 
-pt0  = muons["Muon_pt",  cut, 0]; pt1  = muons["Muon_pt",  cut, 1]
-eta0 = muons["Muon_eta", cut, 0]; eta1 = muons["Muon_eta", cut, 1]
-phi0 = muons["Muon_phi", cut, 0]; phi1 = muons["Muon_phi", cut, 1]
+pt0 = muons["Muon_pt", cut, 0]
+pt1 = muons["Muon_pt", cut, 1]
+eta0 = muons["Muon_eta", cut, 0]
+eta1 = muons["Muon_eta", cut, 1]
+phi0 = muons["Muon_phi", cut, 0]
+phi1 = muons["Muon_phi", cut, 1]
 
 import numpy as np
-mass = np.sqrt(2*pt0*pt1*(np.cosh(eta0 - eta1) - np.cos(phi0 - phi1)))
+
+mass = np.sqrt(2 * pt0 * pt1 * (np.cosh(eta0 - eta1) - np.cos(phi0 - phi1)))
 
 import hist
+
 masshist = hist.Hist(hist.axis.Regular(120, 0, 120, label="mass [GeV]"))
 masshist.fill(mass)
 masshist.plot()
@@ -147,12 +157,15 @@ and accumulate data gradually with [uproot.TTree.iterate](https://uproot.readthe
 masshist = hist.Hist(hist.axis.Regular(120, 0, 120, label="mass [GeV]"))
 
 for muons in tree.iterate(filter_name=["nMuon", "/Muon_(pt|eta|phi)/"]):
-    cut = (muons["nMuon"] == 2)
-    pt0  = muons["Muon_pt",  cut, 0]; pt1  = muons["Muon_pt",  cut, 1]
-    eta0 = muons["Muon_eta", cut, 0]; eta1 = muons["Muon_eta", cut, 1]
-    phi0 = muons["Muon_phi", cut, 0]; phi1 = muons["Muon_phi", cut, 1]
+    cut = muons["nMuon"] == 2
+    pt0 = muons["Muon_pt", cut, 0]
+    pt1 = muons["Muon_pt", cut, 1]
+    eta0 = muons["Muon_eta", cut, 0]
+    eta1 = muons["Muon_eta", cut, 1]
+    phi0 = muons["Muon_phi", cut, 0]
+    phi1 = muons["Muon_phi", cut, 1]
 
-    mass = np.sqrt(2*pt0*pt1*(np.cosh(eta0 - eta1) - np.cos(phi0 - phi1)))
+    mass = np.sqrt(2 * pt0 * pt1 * (np.cosh(eta0 - eta1) - np.cos(phi0 - phi1)))
     masshist.fill(mass)
 
     print(masshist.sum() / tree.num_entries)

--- a/_episodes/04-awkward.md
+++ b/_episodes/04-awkward.md
@@ -19,12 +19,11 @@ keypoints:
 
 The previous lesson included a tricky slice:
 
-~~~
+```python
 cut = (muons["nMuon"] == 2)
 
 pt0 = muons["Muon_pt", cut, 0]
-~~~
-{: .language-python}
+```
 
 The three parts of `muons["Muon_pt", cut, 0]` slice
 
@@ -34,19 +33,17 @@ The three parts of `muons["Muon_pt", cut, 0]` slice
 
 NumPy would not be able to perform such a slice, or even represent an array of variable-length lists without resorting to arrays of objects.
 
-~~~
+```python
 import numpy as np
 np.array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
-~~~
-{: .language-python}
+```
 
 Awkward Array is intended to fill this gap:
 
-~~~
+```python
 import awkward as ak
 ak.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
-~~~
-{: .language-python}
+```
 
 Arrays like this are sometimes called "[jagged arrays](https://en.wikipedia.org/wiki/Jagged_array)" and sometimes "ragged arrays."
 
@@ -54,7 +51,7 @@ Arrays like this are sometimes called "[jagged arrays](https://en.wikipedia.org/
 
 Basic slices are a generalization of NumPy's—what NumPy would do if it had variable-length lists.
 
-~~~
+```python
 array = ak.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
 array.tolist()
 
@@ -63,40 +60,36 @@ array[-1, 1]
 array[2:, 0]
 array[2:, 1:]
 array[:, 0]
-~~~
-{: .language-python}
+```
 
 **Quick quiz:** why does the last one raise an error?
 
 Boolean and integer slices work, too:
 
-~~~
+```python
 array[[True, False, True, False, True]]
 
 array[[2, 3, 3, 1]]
-~~~
-{: .language-python}
+```
 
 Like NumPy, boolean arrays for slices can be computed, and functions like [ak.num](https://awkward-array.readthedocs.io/en/latest/_auto/ak.num.html) are helpful for that.
 
-~~~
+```python
 ak.num(array)
 
 ak.num(array) > 0
 
 array[ak.num(array) > 0, 0]
 array[ak.num(array) > 1, 1]
-~~~
-{: .language-python}
+```
 
 Now consider this (similar to an example from the first lesson):
 
-~~~
+```python
 cut = (array * 10 % 2 == 0)
 
 array[cut]
-~~~
-{: .language-python}
+```
 
 This array, `cut`, is not just an array of booleans. It's a jagged array of booleans. All of its nested lists fit into `array`'s nested lists, so it can deeply select numbers, rather than selecting lists.
 
@@ -104,32 +97,29 @@ This array, `cut`, is not just an array of booleans. It's a jagged array of bool
 
 Returning to the big TTree from the previous lesson,
 
-~~~
+```python
 import uproot
 file = uproot.open("root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root")
 tree = file["Events"]
 
 muon_pt = tree["Muon_pt"].array(entry_stop=10)
-~~~
-{: .language-python}
+```
 
 This jagged array of booleans selects all *muons* with at least 20 GeV:
 
-~~~
+```python
 particle_cut = (muon_pt > 20)
 
 muon_pt[particle_cut]
-~~~
-{: .language-python}
+```
 
 and this non-jagged array of booleans (made with [ak.any](https://awkward-array.readthedocs.io/en/latest/_auto/ak.any.html)) selects all events *that have* a muon with at least 20 GeV:
 
-~~~
+```python
 event_cut = ak.any(muon_pt > 20, axis=1)
 
 muon_pt[event_cut]
-~~~
-{: .language-python}
+```
 
 **Quick quiz:** construct exactly the same `event_cut` using [ak.max](https://awkward-array.readthedocs.io/en/latest/_auto/ak.max.html).
 
@@ -137,10 +127,9 @@ muon_pt[event_cut]
 
 Hint: you'll want to make a
 
-~~~
+```python
 cleaned = muon_pt[particle_cut]
-~~~
-{: .language-python}
+```
 
 intermediary and you can't use the variable `event_cut`, as-is.
 
@@ -154,68 +143,62 @@ Awkward Array has functions that generate these combinations. For instance, [ak.
 
 ![cartoon-cartesian]({{ page.root }}/fig/cartoon-cartesian.png)
 
-~~~
+```python
 numbers = ak.Array([[1, 2, 3], [], [5, 7], [11]])
 letters = ak.Array([["a", "b"], ["c"], ["d"], ["e", "f"]])
 
 pairs = ak.cartesian((numbers, letters))
-~~~
-{: .language-python}
+```
 
 These `pairs` are 2-tuples, which are like records in how they're sliced out of an array: using strings.
 
-~~~
+```python
 pairs["0"]
 pairs["1"]
-~~~
-{: .language-python}
+```
 
 There's also [ak.unzip](https://awkward-array.readthedocs.io/en/latest/_auto/ak.unzip.html), which extracts every field into a separate array (opposite of [ak.zip](https://awkward-array.readthedocs.io/en/latest/_auto/ak.zip.html)).
 
-~~~
+```python
 lefts, rights = ak.unzip(pairs)
 lefts
 rights
-~~~
-{: .language-python}
+```
 
 Note that these `lefts` and `rights` are not the original `numbers` and `letters`: they have been duplicated and have the same shape.
 
 The Cartesian product is equivalent to this C++ `for` loop over two collections:
 
-~~~
+```cpp
 for (int i = 0; i < numbers.size(); i++) {
   for (int j = 0; j < letters.size(); j++) {
     // compute formula with numbers[i] and letters[j]
   }
 }
-~~~
-{: .language-cpp}
+```
 
 Sometimes, though, we want to find all pairs within a single collection, without repetition. That would be equivalent to this C++ `for` loop:
 
-~~~
+```cpp
 for (int i = 0; i < numbers.size(); i++) {
   for (int j = i + 1; i < numbers.size(); j++) {
     // compute formula with numbers[i] and numbers[j]
   }
 }
-~~~
-{: .language-cpp}
+```
 
 The Awkward function for this case is [ak.combinations](https://awkward-array.readthedocs.io/en/latest/_auto/ak.combinations.html).
 
 ![cartoon-combinations]({{ page.root }}/fig/cartoon-combinations.png)
 
-~~~
+```python
 pairs = ak.combinations(numbers, 2)
 pairs
 
 lefts, rights = ak.unzip(pairs)
 
 lefts * rights   # they line up, so we can compute formulas
-~~~
-{: .language-python}
+```
 
 ## Application to dimuons
 
@@ -225,7 +208,7 @@ A better procedure would be to look for all pairs of muons in an event and apply
 
 In this example, we'll [ak.zip](https://awkward-array.readthedocs.io/en/latest/_auto/ak.zip.html) the muon variables together into records.
 
-~~~
+```python
 import uproot
 
 file = uproot.open("root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root")
@@ -242,37 +225,33 @@ muons = ak.zip({
 
 arrays.type
 muons.type
-~~~
-{: .language-python}
+```
 
 The difference between `arrays` and `muons` is that `arrays` contains separate lists of `"Muon_pt"`, `"Muon_eta"`, `"Muon_phi"`, `"Muon_charge"`, while `muons` contains lists of records with `"pt"`, `"eta"`, `"phi"`, `"charge"` fields.
 
 Now we can compute pairs of muon *objects*
 
-~~~
+```python
 pairs = ak.combinations(muons, 2)
 
 pairs.type
-~~~
-{: .language-python}
+```
 
 and separate them into arrays of the first muon and the second muon in each pair.
 
-~~~
+```python
 mu1, mu2 = ak.unzip(pairs)
-~~~
-{: .language-python}
+```
 
 **Quick quiz:** how would you ensure that all lists of records in `mu1` and `mu2` have the same lengths? Hint: see [ak.num](https://awkward-array.readthedocs.io/en/latest/_auto/ak.num.html) and [ak.all](https://awkward-array.readthedocs.io/en/latest/_auto/ak.all.html).
 
 Since they do have the same lengths, we can use them in a formula.
 
-~~~
+```python
 import numpy as np
 
 mass = np.sqrt(2*mu1.pt*mu2.pt*(np.cosh(mu1.eta - mu2.eta) - np.cos(mu1.phi - mu2.phi)))
-~~~
-{: .language-python}
+```
 
 **Quick quiz:** how many masses do we have in each event? How does this compare with `muons`, `mu1`, and `mu2`?
 
@@ -282,7 +261,7 @@ Since this `mass` is a jagged array, it can't be directly histogrammed. Histogra
 
 Supposing you just want to plot the numbers from the lists, you can use [ak.flatten](https://awkward-array.readthedocs.io/en/latest/_auto/ak.flatten.html) to flatten one level of list or [ak.ravel](https://awkward-array.readthedocs.io/en/latest/_auto/ak.ravel.html) to flatten all levels.
 
-~~~
+```python
 import hist
 
 hist.Hist(hist.axis.Regular(120, 0, 120, label="mass [GeV]")).fill(
@@ -290,29 +269,25 @@ hist.Hist(hist.axis.Regular(120, 0, 120, label="mass [GeV]")).fill(
     ak.ravel(mass)
 
 ).plot()
-~~~
-{: .language-python}
+```
 
 Alternatively, suppose you want to plot the *maximum* mass-candidate in each event, biasing it toward Z bosons? [ak.max](https://awkward-array.readthedocs.io/en/latest/_auto/ak.max.html) is a different function that picks one element from each list, when used with `axis=1`.
 
-~~~
+```python
 ak.max(mass, axis=1)
-~~~
-{: .language-python}
+```
 
 Some values are `None` because there is no maximum of an empty list. [ak.flatten](https://awkward-array.readthedocs.io/en/latest/_auto/ak.flatten.html)/[ak.ravel](https://awkward-array.readthedocs.io/en/latest/_auto/ak.ravel.html) remove missing values (`None`) as well as squashing lists,
 
-~~~
+```python
 ak.flatten(ak.max(mass, axis=1), axis=0)
-~~~
-{: .language-python}
+```
 
 but so does removing the empty lists in the first place.
 
-~~~
+```python
 ak.max(mass[ak.num(mass) > 0], axis=1)
-~~~
-{: .language-python}
+```
 
 > ## Exercise: select pairs of muons with opposite charges
 >
@@ -322,21 +297,19 @@ ak.max(mass[ak.num(mass) > 0], axis=1)
 > >
 > > The `mu1` and `mu2` variables are the left and right halves of muon pairs. Therefore,
 > >
-> > ~~~
+> > ```python
 > > cut = (mu1.charge != mu2.charge)
-> > ~~~
-> > {: .language-python}
+> > ```
 > >
 > > has the right multiplicity to be applied to the `mass` array.
 > >
-> > ~~~
+> > ```python
 > > hist.Hist(hist.axis.Regular(120, 0, 120, label="mass [GeV]")).fill(
 > >
 > >     ak.ravel(mass[cut])
 > >
 > > ).plot()
-> > ~~~
-> > {: .language-python}
+> > ```
 > >
 > > plots the cleaned muon pairs.
 > {: .solution}
@@ -350,12 +323,11 @@ ak.max(mass[ak.num(mass) > 0], axis=1)
 >
 > Anticipating one of the future lessons, you could get a more accurate mass by asking the Particle library:
 >
-> ~~~
+> ```python
 > import particle, hepunits
 >
 > zmass = particle.Particle.findall("Z0")[0].mass / hepunits.GeV
-> ~~~
-> {: .language-python}
+> ```
 >
 > > ## Solution (no peeking!)
 > >
@@ -363,7 +335,7 @@ ak.max(mass[ak.num(mass) > 0], axis=1)
 > >
 > > The last step would require two applications of [ak.flatten](https://awkward-array.readthedocs.io/en/latest/_auto/ak.flatten.html): one for squashing lists at the first level and another for removing `None` at the second level.
 > >
-> > ~~~
+> > ```python
 > > which = ak.argmin(abs(mass - zmass), axis=1, keepdims=True)
 > >
 > > hist.Hist(hist.axis.Regular(120, 0, 120, label="mass [GeV]")).fill(
@@ -371,8 +343,7 @@ ak.max(mass[ak.num(mass) > 0], axis=1)
 > >     ak.ravel(mass[which])
 > >
 > > ).plot()
-> > ~~~
-> > {: .language-python}
+> > ```
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/04-awkward.md
+++ b/_episodes/04-awkward.md
@@ -20,7 +20,7 @@ keypoints:
 The previous lesson included a tricky slice:
 
 ```python
-cut = (muons["nMuon"] == 2)
+cut = muons["nMuon"] == 2
 
 pt0 = muons["Muon_pt", cut, 0]
 ```
@@ -35,6 +35,7 @@ NumPy would not be able to perform such a slice, or even represent an array of v
 
 ```python
 import numpy as np
+
 np.array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
 ```
 
@@ -42,6 +43,7 @@ Awkward Array is intended to fill this gap:
 
 ```python
 import awkward as ak
+
 ak.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
 ```
 
@@ -86,7 +88,7 @@ array[ak.num(array) > 1, 1]
 Now consider this (similar to an example from the first lesson):
 
 ```python
-cut = (array * 10 % 2 == 0)
+cut = array * 10 % 2 == 0
 
 array[cut]
 ```
@@ -99,7 +101,10 @@ Returning to the big TTree from the previous lesson,
 
 ```python
 import uproot
-file = uproot.open("root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root")
+
+file = uproot.open(
+    "root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root"
+)
 tree = file["Events"]
 
 muon_pt = tree["Muon_pt"].array(entry_stop=10)
@@ -108,7 +113,7 @@ muon_pt = tree["Muon_pt"].array(entry_stop=10)
 This jagged array of booleans selects all *muons* with at least 20 GeV:
 
 ```python
-particle_cut = (muon_pt > 20)
+particle_cut = muon_pt > 20
 
 muon_pt[particle_cut]
 ```
@@ -197,7 +202,7 @@ pairs
 
 lefts, rights = ak.unzip(pairs)
 
-lefts * rights   # they line up, so we can compute formulas
+lefts * rights  # they line up, so we can compute formulas
 ```
 
 ## Application to dimuons
@@ -211,17 +216,21 @@ In this example, we'll [ak.zip](https://awkward-array.readthedocs.io/en/latest/_
 ```python
 import uproot
 
-file = uproot.open("root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root")
+file = uproot.open(
+    "root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root"
+)
 tree = file["Events"]
 
 arrays = tree.arrays(filter_name="/Muon_(pt|eta|phi|charge)/", entry_stop=10000)
 
-muons = ak.zip({
-    "pt": arrays["Muon_pt"],
-    "eta": arrays["Muon_eta"],
-    "phi": arrays["Muon_phi"],
-    "charge": arrays["Muon_charge"],
-})
+muons = ak.zip(
+    {
+        "pt": arrays["Muon_pt"],
+        "eta": arrays["Muon_eta"],
+        "phi": arrays["Muon_phi"],
+        "charge": arrays["Muon_charge"],
+    }
+)
 
 arrays.type
 muons.type
@@ -250,7 +259,9 @@ Since they do have the same lengths, we can use them in a formula.
 ```python
 import numpy as np
 
-mass = np.sqrt(2*mu1.pt*mu2.pt*(np.cosh(mu1.eta - mu2.eta) - np.cos(mu1.phi - mu2.phi)))
+mass = np.sqrt(
+    2 * mu1.pt * mu2.pt * (np.cosh(mu1.eta - mu2.eta) - np.cos(mu1.phi - mu2.phi))
+)
 ```
 
 **Quick quiz:** how many masses do we have in each event? How does this compare with `muons`, `mu1`, and `mu2`?
@@ -265,9 +276,7 @@ Supposing you just want to plot the numbers from the lists, you can use [ak.flat
 import hist
 
 hist.Hist(hist.axis.Regular(120, 0, 120, label="mass [GeV]")).fill(
-
     ak.ravel(mass)
-
 ).plot()
 ```
 

--- a/_episodes/05-histograms.md
+++ b/_episodes/05-histograms.md
@@ -82,19 +82,19 @@ h[10:110].plot()
 but often you want to select bins by coordinate value
 
 ```python
-h[hist.loc(90):].plot()
+h[hist.loc(90) :].plot()
 ```
 
 or rebin by a factor,
 
 ```python
-h[::hist.rebin(2)].plot()
+h[:: hist.rebin(2)].plot()
 ```
 
 or sum over a range.
 
 ```python
-h[hist.loc(80):hist.loc(100):sum]
+h[hist.loc(80) : hist.loc(100) : sum]
 ```
 
 Things get more interesting when a histogram has multiple dimensions.
@@ -102,7 +102,9 @@ Things get more interesting when a histogram has multiple dimensions.
 ```python
 import awkward as ak
 
-picodst = uproot.open("https://pivarski-princeton.s3.amazonaws.com/pythia_ppZee_run17emb.picoDst.root:PicoDst")
+picodst = uproot.open(
+    "https://pivarski-princeton.s3.amazonaws.com/pythia_ppZee_run17emb.picoDst.root:PicoDst"
+)
 
 vertexhist = hist.Hist(
     hist.axis.Regular(600, -1, 1, label="x"),
@@ -119,9 +121,13 @@ vertexhist.fill(
 )
 
 vertexhist[:, :, sum].plot2d_full()
-vertexhist[hist.loc(-0.25):hist.loc(0.25), hist.loc(-0.25):hist.loc(0.25), sum].plot2d_full()
+vertexhist[
+    hist.loc(-0.25) : hist.loc(0.25), hist.loc(-0.25) : hist.loc(0.25), sum
+].plot2d_full()
 vertexhist[sum, sum, :].plot()
-vertexhist[hist.loc(-0.25):hist.loc(0.25):sum, hist.loc(-0.25):hist.loc(0.25):sum, :].plot()
+vertexhist[
+    hist.loc(-0.25) : hist.loc(0.25) : sum, hist.loc(-0.25) : hist.loc(0.25) : sum, :
+].plot()
 ```
 
 A histogram object can have more dimensions than you can reasonably visualize—you can slice, rebin, and project it into something visual later.
@@ -135,10 +141,17 @@ import iminuit.cost
 
 norm = len(h.axes[0].widths) / (h.axes[0].edges[-1] - h.axes[0].edges[0]) / h.sum()
 
-def f(x, background, mu, gamma):
-    return background + (1 - background) * gamma**2/((x - mu)**2 + gamma**2)/np.pi/gamma
 
-loss = iminuit.cost.LeastSquares(h.axes[0].centers, h.values() * norm, np.sqrt(h.variances()) * norm, f)
+def f(x, background, mu, gamma):
+    return (
+        background
+        + (1 - background) * gamma**2 / ((x - mu) ** 2 + gamma**2) / np.pi / gamma
+    )
+
+
+loss = iminuit.cost.LeastSquares(
+    h.axes[0].centers, h.values() * norm, np.sqrt(h.variances()) * norm, f
+)
 loss.mask = h.variances() > 0
 
 minimizer = iminuit.Minuit(loss, background=0, mu=91, gamma=4)
@@ -163,7 +176,9 @@ space = zfit.Space("mass", binning=binning)
 background = zfit.Parameter("background", 0)
 mu = zfit.Parameter("mu", 91)
 gamma = zfit.Parameter("gamma", 4)
-unbinned_model = zfit.pdf.SumPDF([zfit.pdf.Uniform(60, 120, space), zfit.pdf.Cauchy(mu, gamma, space)], [background])
+unbinned_model = zfit.pdf.SumPDF(
+    [zfit.pdf.Uniform(60, 120, space), zfit.pdf.Cauchy(mu, gamma, space)], [background]
+)
 
 model = zfit.pdf.BinnedFromUnbinnedPDF(unbinned_model, space)
 loss = zfit.loss.BinnedNLL(model, binned_data)

--- a/_episodes/05-histograms.md
+++ b/_episodes/05-histograms.md
@@ -23,7 +23,7 @@ Mainstream Python has libraries for filling histograms.
 
 NumPy, for instance, has an [np.histogram](https://numpy.org/doc/stable/reference/generated/numpy.histogram.html) function.
 
-~~~
+```python
 import skhep_testdata, uproot
 
 tree = uproot.open(skhep_testdata.data_path("uproot-Zmumu.root"))["events"]
@@ -31,8 +31,7 @@ tree = uproot.open(skhep_testdata.data_path("uproot-Zmumu.root"))["events"]
 import numpy as np
 
 np.histogram(tree["M"].array())
-~~~
-{: .language-python}
+```
 
 Because of NumPy's prominence, this 2-tuple of arrays (bin contents and edges) is a widely recognized histogram format, though it lacks many of the features high-energy physicists expect (under/overflow, axis labels, uncertainties, etc.).
 
@@ -40,12 +39,11 @@ Because of NumPy's prominence, this 2-tuple of arrays (bin contents and edges) i
 
 Matplotlib also has a [plt.hist](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.hist.html) function.
 
-~~~
+```python
 import matplotlib.pyplot as plt
 
 plt.hist(tree["M"].array())
-~~~
-{: .language-python}
+```
 
 In addition to the same bin contents and edges as NumPy, Matplotlib includes a plottable graphic.
 
@@ -55,14 +53,13 @@ The main feature that these functions lack (without some effort) is refillabilit
 
 Boost-histogram is a library designed for that purpose:
 
-~~~
+```python
 import boost_histogram as bh
-~~~
-{: .language-python}
+```
 
 This library is intended as an infrastructure component; a more user-friendly layer (with plotting, for instance) is provided by a library called "hist."
 
-~~~
+```python
 import hist
 
 h = hist.Hist(hist.axis.Regular(120, 60, 120, name="mass"))
@@ -70,8 +67,7 @@ h = hist.Hist(hist.axis.Regular(120, 60, 120, name="mass"))
 h.fill(tree["M"].array())
 
 h.plot()
-~~~
-{: .language-python}
+```
 
 ## Universal Histogram Indexing (UHI)
 
@@ -79,35 +75,31 @@ There is an attempt within Scikit-HEP to standardize what array-like slices mean
 
 Naturally, integer slices should select a range of bins,
 
-~~~
+```python
 h[10:110].plot()
-~~~
-{: .language-python}
+```
 
 but often you want to select bins by coordinate value
 
-~~~
+```python
 h[hist.loc(90):].plot()
-~~~
-{: .language-python}
+```
 
 or rebin by a factor,
 
-~~~
+```python
 h[::hist.rebin(2)].plot()
-~~~
-{: .language-python}
+```
 
 or sum over a range.
 
-~~~
+```python
 h[hist.loc(80):hist.loc(100):sum]
-~~~
-{: .language-python}
+```
 
 Things get more interesting when a histogram has multiple dimensions.
 
-~~~
+```python
 import awkward as ak
 
 picodst = uproot.open("https://pivarski-princeton.s3.amazonaws.com/pythia_ppZee_run17emb.picoDst.root:PicoDst")
@@ -130,8 +122,7 @@ vertexhist[:, :, sum].plot2d_full()
 vertexhist[hist.loc(-0.25):hist.loc(0.25), hist.loc(-0.25):hist.loc(0.25), sum].plot2d_full()
 vertexhist[sum, sum, :].plot()
 vertexhist[hist.loc(-0.25):hist.loc(0.25):sum, hist.loc(-0.25):hist.loc(0.25):sum, :].plot()
-~~~
-{: .language-python}
+```
 
 A histogram object can have more dimensions than you can reasonably visualize—you can slice, rebin, and project it into something visual later.
 
@@ -139,7 +130,7 @@ A histogram object can have more dimensions than you can reasonably visualize—
 
 By directly writing a loss function in Minuit:
 
-~~~
+```python
 import iminuit.cost
 
 norm = len(h.axes[0].widths) / (h.axes[0].edges[-1] - h.axes[0].edges[0]) / h.sum()
@@ -157,12 +148,11 @@ minimizer.hesse()
 
 (h * norm).plot()
 plt.plot(loss.x, f(loss.x, *minimizer.values))
-~~~
-{: .language-python}
+```
 
 Or through zfit, a Pythonic RooFit-like fitter:
 
-~~~
+```python
 import zfit
 
 binned_data = zfit.data.BinnedData.from_hist(h)
@@ -183,7 +173,6 @@ result = minimizer.minimize(loss)
 
 binned_data.to_hist().plot(density=1)
 model.to_hist().plot(density=1)
-~~~
-{: .language-python}
+```
 
 {% include links.md %}

--- a/_episodes/06-lorentz-vectors.md
+++ b/_episodes/06-lorentz-vectors.md
@@ -17,7 +17,7 @@ keypoints:
 
 In keeping with the "many small packages" philosophy, 2D/3D/Lorentz vectors are handled by a package named Vector. This is where you can find calculations like `deltaR` and coordinate transformations.
 
-~~~
+```python
 import vector
 
 one = vector.obj(px=1, py=0, pz=0)
@@ -29,14 +29,13 @@ one.deltaR(two)
 
 one.to_rhophieta()
 two.to_rhophieta()
-~~~
-{: .language-python}
+```
 
 To fit in with the rest of the ecosystem, Vector must be an array-oriented library. Arrays of 2D/3D/Lorentz vectors are processed in bulk.
 
 `MomentumNumpy2D`, `MomentumNumpy3D`, `MomentumNumpy4D` are NumPy array subtypes: NumPy arrays can be *cast* to these types and get all the vector functions.
 
-~~~
+```python
 import skhep_testdata, uproot
 import awkward as ak
 
@@ -57,12 +56,11 @@ one.deltaR(two)
 
 one.to_rhophieta()
 two.to_rhophieta()
-~~~
-{: .language-python}
+```
 
 After `vector.register_awkward()` is called, `"Momentum2D"`, `"Momentum3D"`, `"Momentum4D"` are record names that Awkward Array will recognize to get all the vector functions.
 
-~~~
+```python
 vector.register_awkward()
 
 tree = uproot.open(skhep_testdata.data_path("uproot-HZZ.root"))["events"]
@@ -77,14 +75,13 @@ mu1 + mu2
 mu1.deltaR(mu2)
 
 muons.to_rhophieta()
-~~~
-{: .language-python}
+```
 
 # Particle PDG
 
 The Particle library provides all of the particle masses, decay widths, etc.
 
-~~~
+```python
 import particle
 from hepunits import GeV
 
@@ -96,8 +93,7 @@ z_boson.mass / GeV, z_boson.width / GeV
 particle.Particle.from_pdgid(111)
 
 particle.Particle.findall(lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.pdgid.has_charm)
-~~~
-{: .language-python}
+```
 
 # Jet clustering
 
@@ -105,7 +101,7 @@ In a high-energy pp collision, for instance, a spray of hadrons is produced whic
 
 Some people need to do jet-clustering at the analysis level. The fastjet package makes it possible to do that an (Awkward) array at a time.
 
-~~~
+```python
 picodst = uproot.open("https://pivarski-princeton.s3.amazonaws.com/pythia_ppZee_run17emb.picoDst.root:PicoDst")
 px, py, pz = ak.unzip(picodst.arrays(filter_name=["Track/Track.mPMomentum[XYZ]"], entry_stop=100))
 
@@ -122,8 +118,7 @@ clusterseq = fastjet.ClusterSequence(good_pseudojets, jetdef)
 clusterseq.inclusive_jets()
 
 ak.num(good_pseudojets), ak.num(clusterseq.inclusive_jets())
-~~~
-{: .language-python}
+```
 
 This fastjet package uses Vector to get coordinate transformations and all the Lorentz vector methods you're accustomed to having in pseudo-jet objects. I used Particle to impute the mass of particles with only track-level information.
 

--- a/_episodes/06-lorentz-vectors.md
+++ b/_episodes/06-lorentz-vectors.md
@@ -67,7 +67,10 @@ tree = uproot.open(skhep_testdata.data_path("uproot-HZZ.root"))["events"]
 
 array = tree.arrays(filter_name=["Muon_E", "Muon_P[xyz]"])
 
-muons = ak.zip({"px": array.Muon_Px, "py": array.Muon_Py, "pz": array.Muon_Pz, "E": array.Muon_E}, with_name="Momentum4D")
+muons = ak.zip(
+    {"px": array.Muon_Px, "py": array.Muon_Py, "pz": array.Muon_Pz, "E": array.Muon_E},
+    with_name="Momentum4D",
+)
 mu1, mu2 = ak.unzip(ak.combinations(muons, 2))
 
 mu1 + mu2
@@ -92,7 +95,9 @@ z_boson.mass / GeV, z_boson.width / GeV
 
 particle.Particle.from_pdgid(111)
 
-particle.Particle.findall(lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.pdgid.has_charm)
+particle.Particle.findall(
+    lambda p: p.pdgid.is_meson and p.pdgid.has_strange and p.pdgid.has_charm
+)
 ```
 
 # Jet clustering
@@ -102,12 +107,18 @@ In a high-energy pp collision, for instance, a spray of hadrons is produced whic
 Some people need to do jet-clustering at the analysis level. The fastjet package makes it possible to do that an (Awkward) array at a time.
 
 ```python
-picodst = uproot.open("https://pivarski-princeton.s3.amazonaws.com/pythia_ppZee_run17emb.picoDst.root:PicoDst")
-px, py, pz = ak.unzip(picodst.arrays(filter_name=["Track/Track.mPMomentum[XYZ]"], entry_stop=100))
+picodst = uproot.open(
+    "https://pivarski-princeton.s3.amazonaws.com/pythia_ppZee_run17emb.picoDst.root:PicoDst"
+)
+px, py, pz = ak.unzip(
+    picodst.arrays(filter_name=["Track/Track.mPMomentum[XYZ]"], entry_stop=100)
+)
 
 probable_mass = particle.Particle.from_string("pi+").mass / GeV
 
-pseudojets = ak.zip({"px": px, "py": py, "pz": pz, "mass": probable_mass}, with_name="Momentum4D")
+pseudojets = ak.zip(
+    {"px": px, "py": py, "pz": pz, "mass": probable_mass}, with_name="Momentum4D"
+)
 good_pseudojets = pseudojets[pseudojets.pt > 0.1]
 
 import fastjet

--- a/setup.md
+++ b/setup.md
@@ -72,12 +72,11 @@ Simply click the following button:
 
 If you want to install some of these packages on your own or your lab's computer, I recommend [Miniforge](https://github.com/conda-forge/miniforge) (or Anaconda/Miniconda with the [conda-forge channel](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge)). This method also provides a way to [install ROOT in the same environment](https://github.com/conda-forge/root-feedstock#readme). To setup the environment use the environment.yml file in base of this repository as:
 
-
 ```bash
-conda env create --file environment.yml
+conda install uproot awkward   # ... others?
 ```
 
-Alternatively, you can install all required packages locally with pip: Take a look at environment.yml for a list (this includes all dependencies listed under the pip key and some of the dependencies listed above).
+Alternatively, you can install all required packages locally with pip: Take a look at requirements.txt for a list.
 
 
 {% include links.md %}


### PR DESCRIPTION
Using:

```fish
gsed -i ':a;N;$!ba;s/~~~\([^~]*\)~~~\n{: .language-python}/```python\1```/g' **.md
```

to do (most of) the conversion.
