### PR TITLE
"TTree details", "Jagged, ragged, Awkward Arrays" -> slight improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
 # === END CENTRALLY MAINTAINED FILE ===
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.14.0
+    rev: 1.15.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==22.6.0]

--- a/_episodes/04-awkward.md
+++ b/_episodes/04-awkward.md
@@ -36,7 +36,7 @@ NumPy would not be able to perform such a slice, or even represent an array of v
 
 ~~~
 import numpy as np
-np.array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
+np.array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]]) # generates a ValueError
 ~~~
 {: .language-python}
 
@@ -232,6 +232,8 @@ file = uproot.open("root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2
 tree = file["Events"]
 
 arrays = tree.arrays(filter_name="/Muon_(pt|eta|phi|charge)/", entry_stop=10000)
+
+import awkward as ak
 
 muons = ak.zip({
     "pt": arrays["Muon_pt"],

--- a/_episodes/04-awkward.md
+++ b/_episodes/04-awkward.md
@@ -35,6 +35,7 @@ NumPy would not be able to perform such a slice, or even represent an array of v
 
 ```python
 import numpy as np
+
 # generates a ValueError
 np.array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
 ```


### PR DESCRIPTION
TTree details:
Remove two empty lines which result in misbehaving code (broken indentation) when one uses copy/paste (with a mouse) to execute it.

Jagged, ragged, Awkward Arrays:
Added a comment about an expected ValueError message.
Added an "import" to make an example fully self-contained.