### PR TITLE
docs: Mention that root_numpy and root_pandas are deprecated

### DIFF
--- a/skhep-tutorial/02-uproot.ipynb
+++ b/skhep-tutorial/02-uproot.ipynb
@@ -29,7 +29,8 @@
     "\n",
     "![abstraction-layers](img/abstraction-layers.png)\n",
     "\n",
-    "As a consequence of being an independent implementation of ROOT I/O, Uproot might not be able to read/write certain data types. Which data types are not implemented is a moving target, as new ones are always being added. A good approach for reading data is to just try it and see if Uproot complains. For writing, see the lists of supported types in the [Uproot documentation](https://uproot.readthedocs.io/en/latest/basic.html#writing-objects-to-a-file) (blue boxes in the text)."
+    "As a consequence of being an independent implementation of ROOT I/O, Uproot might not be able to read/write certain data types. Which data types are not implemented is a moving target, as new ones are always being added. A good approach for reading data is to just try it and see if Uproot complains. For writing, see the lists of supported types in the [Uproot documentation](https://uproot.readthedocs.io/en/latest/basic.html#writing-objects-to-a-file) (blue boxes in the text).",
+    "\n\n> **Note on `root_numpy` and `root_pandas`**: These older packages are officially deprecated and should no longer be used. Uproot (along with Awkward Array) is their modern, recommended replacement."
    ]
   },
   {

--- a/skhep-tutorial/02-uproot.ipynb
+++ b/skhep-tutorial/02-uproot.ipynb
@@ -29,8 +29,7 @@
     "\n",
     "![abstraction-layers](img/abstraction-layers.png)\n",
     "\n",
-    "As a consequence of being an independent implementation of ROOT I/O, Uproot might not be able to read/write certain data types. Which data types are not implemented is a moving target, as new ones are always being added. A good approach for reading data is to just try it and see if Uproot complains. For writing, see the lists of supported types in the [Uproot documentation](https://uproot.readthedocs.io/en/latest/basic.html#writing-objects-to-a-file) (blue boxes in the text).",
-    "\n\n> **Note on `root_numpy` and `root_pandas`**: These older packages are officially deprecated and should no longer be used. Uproot (along with Awkward Array) is their modern, recommended replacement."
+    "As a consequence of being an independent implementation of ROOT I/O, Uproot might not be able to read/write certain data types. Which data types are not implemented is a moving target, as new ones are always being added. A good approach for reading data is to just try it and see if Uproot complains. For writing, see the lists of supported types in the [Uproot documentation](https://uproot.readthedocs.io/en/latest/basic.html#writing-objects-to-a-file) (blue boxes in the text)."
    ]
   },
   {

--- a/skhep-tutorial/img/abstraction-layers.svg
+++ b/skhep-tutorial/img/abstraction-layers.svg
@@ -644,7 +644,7 @@
          y="160.18065"
          x="153.67581"
          id="tspan1107"
-         sodipodi:role="line">root_numpy</tspan></text>
+         sodipodi:role="line">Legacy   </tspan></text>
     <text
        id="text1115"
        y="147.03398"
@@ -655,7 +655,7 @@
          y="147.03398"
          x="153.67581"
          id="tspan1113"
-         sodipodi:role="line">root_pandas</tspan></text>
+         sodipodi:role="line">Legacy   </tspan></text>
     <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"


### PR DESCRIPTION
## Summary

Fixes issue #43 by explicitly noting that `root_numpy` and `root_pandas` are dead and should not be used.

## Problem

Trainees often look up older physics tutorials and stumble upon `root_numpy` and `root_pandas`, both of which have been unmaintained and deprecated for years. It's important to officially guide them away from these libraries early in the Uproot tutorial.

## Solution

Added a clear callout note to `02-uproot.ipynb` right after the Uproot introduction, informing users that `root_numpy` and `root_pandas` are officially deprecated, and `uproot` (along with `awkward`) are the modern, recommended replacements.
