### PR TITLE
fix: Move pythia_ppZee_run17emb.picoDst.root URL to Zenodo

### DIFF
--- a/skhep-tutorial/05-histograms.ipynb
+++ b/skhep-tutorial/05-histograms.ipynb
@@ -234,7 +234,7 @@
     "import awkward as ak\n",
     "\n",
     "picodst = uproot.open(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/pythia_ppZee_run17emb.picoDst.root:PicoDst\"\n",
+    "    \"https://zenodo.org/records/21777191/files/pythia_ppZee_run17emb.picoDst.root:PicoDst\"\n",
     ")\n",
     "\n",
     "vertexhist = hist.Hist(\n",

--- a/skhep-tutorial/06-lorentz-vectors.ipynb
+++ b/skhep-tutorial/06-lorentz-vectors.ipynb
@@ -300,7 +300,7 @@
     "vector.register_awkward()\n",
     "\n",
     "picodst = uproot.open(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/pythia_ppZee_run17emb.picoDst.root:PicoDst\"\n",
+    "    \"https://zenodo.org/records/21777191/files/pythia_ppZee_run17emb.picoDst.root:PicoDst\"\n",
     ")\n",
     "px, py, pz = ak.unzip(\n",
     "    picodst.arrays(filter_name=[\"Track/Track.mPMomentum[XYZ]\"], entry_stop=100)\n",


### PR DESCRIPTION
Closes #97

:robot: _AI text below_ :robot:

The AWS S3 bucket hosting `pythia_ppZee_run17emb.picoDst.root` is being taken down on August 31, 2026 due to data transfer charges. The file is now hosted on [Zenodo](https://zenodo.org/records/21777191).

Updates the two `uproot.open(...)` calls that referenced it:

- `skhep-tutorial/05-histograms.ipynb`
- `skhep-tutorial/06-lorentz-vectors.ipynb`

### Note on the URL form

The issue gives `.../pythia_ppZee_run17emb.picoDst.root?download=1`, which is correct for `wget` but not here. Appending uproot's `:PicoDst` object suffix yields `?download=1:PicoDst` — the object name gets absorbed into the query string, so `uproot.open` silently returns the file's root directory (a `ReadOnlyDirectory`) instead of the `TTree`, and the following line fails. This PR uses the plain file URL without the query parameter.

### Verification

Checked against the live Zenodo URL:

- Range requests are supported (`HTTP 206`), so uproot's partial reads work.
- Both notebook cells' actual reads succeed: 100 entries / 272,347 tracks for the Lorentz-vectors cell, and 8,004 entries with all three `Event.mPrimaryVertex[XYZ]` fields for the histograms cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)