### PR TITLE
docs: Use mktree for TTrees and Pythonic syntax for RNTuples

### DIFF
--- a/skhep-tutorial/02-uproot.ipynb
+++ b/skhep-tutorial/02-uproot.ipynb
@@ -412,7 +412,11 @@
     "\n",
     "TTrees are potentially large and might not fit in memory. Generally, you'll need to write them in batches.\n",
     "\n",
-    "To do that, first create an empty TTree with [uproot.WritableDirectory.mktree](https://uproot.readthedocs.io/en/latest/uproot.writing.writable.WritableDirectory.html#mktree), giving the name and data type of each branch, and then fill it by calling `extend` once per batch."
+    "```{warning}\n",
+    "Assigning data to a key of the file, as in `output1[\"tree1\"] = {\"x\": ..., \"y\": ...}`, does *not* make a TTree: recent versions of Uproot write an RNTuple in that case (more on this below). Use `mktree` whenever you specifically want a TTree.\n",
+    "```\n",
+    "\n",
+    "One way to do this is to create the TTree with [uproot.WritableDirectory.mktree](https://uproot.readthedocs.io/en/latest/uproot.writing.writable.WritableDirectory.html#mktree), passing the first batch of data, and `extend` it with subsequent batches:"
    ]
   },
   {
@@ -424,10 +428,9 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "output1.mktree(\"tree1\", {\"x\": np.int32, \"y\": np.float64})\n",
-    "\n",
-    "output1[\"tree1\"].extend(\n",
-    "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
+    "output1.mktree(\n",
+    "    \"tree1\",\n",
+    "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)},\n",
     ")\n",
     "output1[\"tree1\"].extend(\n",
     "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
@@ -442,14 +445,31 @@
    "id": "41",
    "metadata": {},
    "source": [
-    "```{warning}\n",
-    "Assigning data to a key of the file, as in `output1[\"tree1\"] = {\"x\": ..., \"y\": ...}`, does *not* make a TTree: recent versions of Uproot write an RNTuple in that case (more on this below). Use `mktree` whenever you specifically want a TTree.\n",
-    "```"
+    "another is to pass the data types instead of the data itself, which creates an empty TTree, so that every write is an extension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output1.mktree(\"tree2\", {\"x\": np.int32, \"y\": np.float64})\n",
+    "output1[\"tree2\"].extend(\n",
+    "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
+    ")\n",
+    "output1[\"tree2\"].extend(\n",
+    "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
+    ")\n",
+    "output1[\"tree2\"].extend(\n",
+    "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "Performance tips are given in the next lesson, but in general, it pays to write few large batches, rather than many small batches.\n",
@@ -459,7 +479,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "# Reading and writing RNTuples\n",
@@ -476,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "This time, if we print the class names, we see that there is an RNTuple instead of a TTree."
@@ -496,7 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +525,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "Let's look at the available keys with `.keys`, but restrict to only keys at the top level by using `recursive=False`."
@@ -514,7 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +544,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "We can show the structure of the RNTuple more clearly by using `.show`, which works in a similar way to TTrees, but it is more complete and shows the structure better since RNTuples are fully readable by Uproot."
@@ -533,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,7 +562,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "Reading data into arrays works in the exact same way as for TTrees, so you don't have to worry to distinguish when you are reading a TTree or an RNTuple."
@@ -551,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +581,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "Writing is even simpler than for TTrees: just assign the data to a key of the file, in the same Pythonic way as for strings and histograms. As of Uproot 5.7, this writes an RNTuple (in older versions it wrote a TTree), and the resulting object can be extended with more batches, just like a TTree."
@@ -570,7 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +605,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "If you'd rather declare the fields up front and make every write an extension, [uproot.WritableDirectory.mkrntuple](https://uproot.readthedocs.io/en/latest/uproot.writing.writable.WritableDirectory.html#mkrntuple) is the RNTuple counterpart of `mktree`."
@@ -593,7 +613,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "For the rest of the tutorial we will mostly stick to using TTrees since this is still the main data format that you'll encounter in the near future."
@@ -601,7 +621,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "source": [
     "`````{tip}\n",
@@ -657,7 +677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/skhep-tutorial/02-uproot.ipynb
+++ b/skhep-tutorial/02-uproot.ipynb
@@ -412,7 +412,7 @@
     "\n",
     "TTrees are potentially large and might not fit in memory. Generally, you'll need to write them in batches.\n",
     "\n",
-    "One way to do this is to assign the first batch and `extend` it with subsequent batches:"
+    "To do that, first create an empty TTree with [uproot.WritableDirectory.mktree](https://uproot.readthedocs.io/en/latest/uproot.writing.writable.WritableDirectory.html#mktree), giving the name and data type of each branch, and then fill it by calling `extend` once per batch."
    ]
   },
   {
@@ -424,10 +424,11 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "output1[\"tree1\"] = {\n",
-    "    \"x\": np.random.randint(0, 10, 1000000),\n",
-    "    \"y\": np.random.normal(0, 1, 1000000),\n",
-    "}\n",
+    "output1.mktree(\"tree1\", {\"x\": np.int32, \"y\": np.float64})\n",
+    "\n",
+    "output1[\"tree1\"].extend(\n",
+    "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
+    ")\n",
     "output1[\"tree1\"].extend(\n",
     "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
     ")\n",
@@ -441,41 +442,24 @@
    "id": "41",
    "metadata": {},
    "source": [
-    "another is to create an empty TTree with [uproot.WritableDirectory.mktree](https://uproot.readthedocs.io/en/latest/uproot.writing.writable.WritableDirectory.html#mktree), so that every write is an extension."
+    "```{warning}\n",
+    "Assigning data to a key of the file, as in `output1[\"tree1\"] = {\"x\": ..., \"y\": ...}`, does *not* make a TTree: recent versions of Uproot write an RNTuple in that case (more on this below). Use `mktree` whenever you specifically want a TTree.\n",
+    "```"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "42",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "output1.mktree(\"tree2\", {\"x\": np.int32, \"y\": np.float64})\n",
-    "output1[\"tree2\"].extend(\n",
-    "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
-    ")\n",
-    "output1[\"tree2\"].extend(\n",
-    "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
-    ")\n",
-    "output1[\"tree2\"].extend(\n",
-    "    {\"x\": np.random.randint(0, 10, 1000000), \"y\": np.random.normal(0, 1, 1000000)}\n",
-    ")"
+    "Performance tips are given in the next lesson, but in general, it pays to write few large batches, rather than many small batches.\n",
+    "\n",
+    "The only data types that can be passed to `mktree` and `extend` are listed in the blue box [in this documentation](https://uproot.readthedocs.io/en/latest/basic.html#writing-ttrees-to-a-file). This includes jagged arrays (described in the lesson after next), but not more complex types."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "43",
-   "metadata": {},
-   "source": [
-    "Performance tips are given in the next lesson, but in general, it pays to write few large batches, rather than many small batches.\n",
-    "\n",
-    "The only data types that can be assigned or passed to `extend` are listed in the blue box [in this documentation](https://uproot.readthedocs.io/en/latest/basic.html#writing-ttrees-to-a-file). This includes jagged arrays (described in the lesson after next), but not more complex types."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "44",
    "metadata": {},
    "source": [
     "# Reading and writing RNTuples\n",
@@ -492,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +487,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "45",
    "metadata": {},
    "source": [
     "This time, if we print the class names, we see that there is an RNTuple instead of a TTree."
@@ -512,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "47",
    "metadata": {},
    "source": [
     "Let's look at the available keys with `.keys`, but restrict to only keys at the top level by using `recursive=False`."
@@ -530,7 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,7 +524,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "49",
    "metadata": {},
    "source": [
     "We can show the structure of the RNTuple more clearly by using `.show`, which works in a similar way to TTrees, but it is more complete and shows the structure better since RNTuples are fully readable by Uproot."
@@ -549,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +542,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "51",
    "metadata": {},
    "source": [
     "Reading data into arrays works in the exact same way as for TTrees, so you don't have to worry to distinguish when you are reading a TTree or an RNTuple."
@@ -567,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,16 +561,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "53",
    "metadata": {},
    "source": [
-    "Writing again works in a very similar way to TTrees. However, since TTrees are still the default format used in more places, writing something like `file[key] = data` will default to writing the data as a TTree (although it will give us a warning that this will change in the near future). When we want to write an RNTuple, we need to specifically tell Uproot that we want to do so. We can input the data in the same way as for TTrees."
+    "Writing is even simpler than for TTrees: just assign the data to a key of the file, in the same Pythonic way as for strings and histograms. As of Uproot 5.7, this writes an RNTuple (in older versions it wrote a TTree), and the resulting object can be extended with more batches, just like a TTree."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -595,8 +579,16 @@
     "\n",
     "output3 = uproot.recreate(\"new-file-with-rntuple.root\")\n",
     "\n",
-    "rntuple = output3.mkrntuple(\"my_rntuple\", data)\n",
-    "rntuple.extend(more_data)"
+    "output3[\"my_rntuple\"] = data\n",
+    "output3[\"my_rntuple\"].extend(more_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55",
+   "metadata": {},
+   "source": [
+    "If you'd rather declare the fields up front and make every write an extension, [uproot.WritableDirectory.mkrntuple](https://uproot.readthedocs.io/en/latest/uproot.writing.writable.WritableDirectory.html#mkrntuple) is the RNTuple counterpart of `mktree`."
    ]
   },
   {
@@ -618,7 +610,7 @@
     "There is a file in `skhep_testdata` named `ntpl001_staff_rntuple_v1-0-0-0.root` that contains CERN staff data from 1988. As the name suggests, it is an RNTuple and not a TTree.\n",
     "\n",
     "1.  Open it with Uproot, look around at what's in there, and then find the number of French employees who were at least 35 years old, and had one or two children. For bonus points, use `with uproot.open(...) as f:` instead of `f = uproot.open(...)` to follow best practices.\n",
-    "2.  With the selection from the previous part, make a histogram of the employee grade with `np.histogram(data.to_numpy())`, and save it to a new ROOT file. (Convert the data with `.to_numpy()` first: `np.histogram` of an Awkward Array returns Awkward Arrays rather than NumPy arrays, and Uproot would then store that pair as a TTree instead of a histogram.)\n",
+    "2.  With the selection from the previous part, make a histogram of the employee grade with `np.histogram(data.to_numpy())`, and save it to a new ROOT file. (Convert the data with `.to_numpy()` first: `np.histogram` of an Awkward Array returns Awkward Arrays rather than NumPy arrays, and Uproot would not recognize that pair as a histogram.)\n",
     "3.  Read back the file you just made. Open the histogram, use `to_hist()` to convert it to a `hist` histogram, and then plot it with `.plot()`.\n",
     "4.  If you are in a training event, right-click on the image, then click on \"Create New View for Cell Output\", then right-click on the image in the new view, then \"Copy Image\", and paste it as a reply in the Slack channel.\n",
     "\n",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Recent versions of Uproot write an RNTuple when doing `file[key] = data`, so the uproot lesson was out of date. This updates `skhep-tutorial/02-uproot.ipynb`:

**TTree writing**
- Both examples now use `mktree`: the first passes the first batch of data directly (`mktree("tree1", {"x": ..., "y": ...})`) and extends it, the second passes the branch types (`{"x": np.int32, "y": np.float64}`) to make an empty TTree so that every write is an extension.
- Added a warning that assigning to a key no longer creates a TTree.
- "assigned or passed to `extend`" → "passed to `mktree` and `extend`".

**RNTuple writing**
- `mkrntuple("my_rntuple", data)` replaced by the Pythonic `output3["my_rntuple"] = data` + `.extend(more_data)`, and the surrounding text no longer claims that assignment defaults to a TTree with a deprecation warning.
- Added a pointer to `mkrntuple` as the counterpart of `mktree` for declaring fields up front.

**Exercise 1**
- The note said `np.histogram` of an Awkward Array "would then store that pair as a TTree instead of a histogram"; it now raises `TypeError: unrecognized type cannot be written to a ROOT file: tuple`, so the wording was adjusted.

Checked with uproot 5.7.6: the notebook runs cleanly, and the resulting files contain `tree1`/`tree2` as `TTree`s and `my_rntuple` as a `ROOT::RNTuple`.
