### PR TITLE
ci: Group Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a `groups` entry to `.github/dependabot.yml` so all GitHub Actions bumps arrive as a single PR instead of one PR per action, and drops the check frequency from weekly to monthly.

Grouping matches the recommendation in the [Scientific Python development guide](https://learn.scientific-python.org/development/guides/gha-basic/), which notes it is "both cleaner and sometimes required for dependent actions, like `upload-artifact`/`download-artifact`".